### PR TITLE
Add Statistics of the World to Datasets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ listed below. Feel free to add additional links to the dataset.
   1871-2020](https://github.com/jalapic/engsoccerdata)
 - [Awesome Public
   Datasets](https://github.com/awesomedata/awesome-public-datasets)
+- [Statistics of the World](https://statisticsoftheworld.com/api-docs) — Free API for GDP, population, inflation & 440+ economic indicators across 218 countries. Sources: IMF, World Bank, WHO, UN.
 
 # Statistical software
 


### PR DESCRIPTION
Adds [Statistics of the World](https://statisticsoftheworld.com/api-docs) to the Datasets section.

Free API providing GDP, population, inflation, and 440+ economic indicators across 218 countries. Aggregates data from the IMF, World Bank, WHO, and UN into a single normalized REST API.

- JSON responses, no auth required for basic access
- Historical time series, country rankings, and cross-country comparisons
- Sources: IMF World Economic Outlook, World Bank WDI, WHO GHO, UN Population Division